### PR TITLE
Fixing bug in GridSeek when records are missing

### DIFF
--- a/codebase/superdarn/src.lib/tk/grid.1.24/src/gridseek.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/src/gridseek.c
@@ -123,13 +123,14 @@ int GridSeek(int fid,
       if (tfile>tval) fptr=lseek(fid,0,SEEK_SET);
     } else fptr=lseek(fid,0,SEEK_SET);
     if (atme!=NULL) *atme=tfile;
-    while (tval>=tfile) {
+    while (tval>tfile) {
       tptr=lseek(fid,0,SEEK_CUR);
       ptr=DataMapRead(fid);
       if (ptr==NULL) break;
       tfile=GridGetTime(ptr);
       DataMapFree(ptr);
-      if (tval>=tfile) fptr=tptr;
+      /*if (tval>=tfile) fptr=tptr;*/
+      fptr=tptr;
       if (atme !=NULL) *atme=tfile;
     }
     if (tval>tfile) return -1;


### PR DESCRIPTION
This commit fixes an issue identified with trim_grid when there are
records missing in a grid file.  Currently, trim_grid calls GridSeek to
identify the starting record based on the command line option inputs.
If a record is missing, rather than going to the next available record
after the provided start time, GridSeek will point to the last record
before the gap, ie earlier than the provided start time.